### PR TITLE
Rename plugin to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ npm install
 npm start
 ```
 
-See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this plugin.
+See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this app.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,7 +1,7 @@
 # Deploying
 
-If you would like to run your own instance of this plugin, see the [docs for deploying plugins](https://github.com/probot/probot/blob/master/docs/deployment.md).
+If you would like to run your own instance of this app, see the [docs for deployment](https://probot.github.io/docs/deployment/).
 
-This plugin requires these **Permissions & events** for the GitHub App:
+This app requires these **Permissions & events** for the GitHub App:
 
 > **TODO**: List permissions required for deployment here. See [probot/stale](https://github.com/probot/stale/blob/master/docs/deploy.md) for an example.

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 module.exports = (robot) => {
-  // Your plugin code here
-  console.log('Yay, the plugin was loaded!');
-  
-  // For more information on building plugins:
+  // Your code here
+  console.log('Yay, the app was loaded!');
+
+  // For more information on building apps:
   // https://probot.github.io/docs/
-  
-  // To get your plugin running against GitHub, see:
+
+  // To get your app running against GitHub, see:
   // https://probot.github.io/docs/development/
 };


### PR DESCRIPTION
- [x] Rename https://github.com/probot/plugin-template to https://github.com/probot/template.git
- [x] Test that `create-probot-plugin` continues to work thanks to GitHub repository redirects

cc https://github.com/probot/probot/pull/210