### PR TITLE
Fix test command to use standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/{{ owner }}/{{ repo }}.git",
   "scripts": {
     "start": "probot run ./index.js",
-    "test": "mocha && xo --extend probot"
+    "test": "mocha && standard"
   },
   "dependencies": {
     "probot": "^0.7.2"


### PR DESCRIPTION
Per @zeke's comment in https://github.com/probot/template/pull/23#issuecomment-328726750, this fixes the test task to use `standard` instead of `xo`.

cc @JasonEtco @hiimbex 