### PR TITLE
Fix fields in license template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) [year], {{{ author }}}
+Copyright (c) {{{ year }}}, {{{ author }}}
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) [year], {{ author }}
+Copyright (c) [year], {{{ author }}}
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
`[year]` (not a handlebars field) -> `{{{ year }}}`

`{{ author }}` (handlebars field that gets escaped) -> `{{{ author }}}`

Works with https://github.com/probot/create-probot-app/pull/14 to support year field, avoids output like https://github.com/clarkbw/probot-in-progress/commit/c9f60b9d486a94f95cbd38bf0b28889596c7fbaa#diff-9879d6db96fd29134fc802214163b95aR3

```
Copyright (c) [year], Bryan Clark &lt;clarkbw@github.com&gt;
```

