### PR TITLE
Add stub for Jest test file

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,10 @@
+// You can import your modules
+// const index = require('../index')
+
+test('that we can run tests', () => {
+  // your real tests go here
+  expect(1 + 2 + 3).toBe(6)
+})
+
+// For more information about testing with Jest see:
+// https://facebook.github.io/jest/


### PR DESCRIPTION
This creates a `__tests__/index.test.js` file + directory.  

My goal was to make it so that when you run `npm test` for the first time after creating a new probot repo, the tests pass!

Here's the expected output for a new users who has just created their probot app:
<img width="354" alt="screen shot 2017-11-02 at 4 11 11 pm" src="https://user-images.githubusercontent.com/2134/32354806-b7536d0a-bfe8-11e7-8780-90e78d15a7a1.png">

P.S. I'm so happy we've moved to jest! ✨ 