### PR TITLE
Remove comment from `LOG_LEVEL` setting in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@
 APP_ID=
 WEBHOOK_SECRET=development
 
-# Uncomment this to get verbose logging
-# LOG_LEVEL=trace # or `info` to show less
+# Uncomment this to get verbose logging; use `info` to show less
+# LOG_LEVEL=trace
 
 # Go to https://smee.io/new set this to the URL that you are redirected to.
 # WEBHOOK_PROXY_URL=


### PR DESCRIPTION
When I uncomment the example `LOG_LEVEL` setting in .env.example, I get

```
Error: unknown level name: "trace # or `info` to show less"
```

It seems like an env variable value can't have a comment in it. This
commit moves the comment out of the env variable value.