### PR TITLE
Update to Probot 6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest && standard"
   },
   "dependencies": {
-    "probot": "^5.0.0"
+    "probot": "^6.0.0"
   },
   "devDependencies": {
     "jest": "^21.2.1",


### PR DESCRIPTION
```
$ yarn create probot-app my-app
...
Installing Node dependencies!
npm WARN deprecated github@12.1.0: 'github' has been renamed to '@octokit/rest' (https://git.io/vNB11)
```
Updated to probot 6.0 to fix a warning.

https://github.com/probot/probot/releases/tag/v6.0.0
