### PR TITLE
Node dependency version fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "standard": "^10.0.3"
   },
   "engines": {
-    "node": ">= 7.7.0",
+    "node": "8.x",
     "npm": ">= 4.0.0"
   },
   "standard": {


### PR DESCRIPTION
Version "^8.0" are all supported. Initial ones requires `--harmony` flag. However, using "^8.0" throws the same error as present, "8.x" works just fine.