### PR TITLE
Pin node to version 8.10.0 in probot

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest && standard"
   },
   "dependencies": {
+    "node": "^8.10.0",
     "probot": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR makes sure that people that generate their probot using `create-probot-app` are always running node 8.10.0. The `node` package installs a `node` binary in `node_modules/` which makes sure that probot will always run with that version when running through npm commands.

### 📚 Documentation

https://www.npmjs.com/package/node