### PR TITLE
Add probot in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "https://github.com/{{ owner }}/{{ repo }}.git",
   "scripts": {
     "start": "probot run ./index.js",
+    "probot": "probot",
     "test": "jest && standard"
   },
   "dependencies": {


### PR DESCRIPTION
As probot provides many functionalities to be used from cli like `run` and `simulate` . In future it may provide more such utils. To add npm script commands for each would lead to lot of duplication.  I favor to let users do it like this 

`npm run probot simulate`  or `yarn probot simulate` instead of `node_modules/.bin/probot simulate`.