### PR TITLE
npm script to lint code

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/{{ owner }}/{{ repo }}.git",
   "scripts": {
     "start": "probot run ./index.js",
-    "format": "standard --fix",
+    "lint": "standard --fix",
     "test": "jest && standard"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "https://github.com/{{ owner }}/{{ repo }}.git",
   "scripts": {
     "start": "probot run ./index.js",
+    "format" "standard --fix",
     "test": "jest && standard"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/{{ owner }}/{{ repo }}.git",
   "scripts": {
     "start": "probot run ./index.js",
-    "format" "standard --fix",
+    "format": "standard --fix",
     "test": "jest && standard"
   },
   "dependencies": {


### PR DESCRIPTION
It would improve the productivity of developers if they can fix their code to adher to standard guidelines by just writing `npm run format` or `yarn format`