### PR TITLE
use standard fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/{{ owner }}/{{ repo }}.git",
   "scripts": {
     "start": "probot run ./index.js",
-    "test": "jest && standard"
+    "test": "jest && standard --fix"
   },
   "dependencies": {
     "probot": "^6.0.0"


### PR DESCRIPTION
This PR updates the test script to use `standard --fix`, which can clean up a lot of minor linting issues for you automatically.