### PR TITLE
fixes #55

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,1 +1,0 @@
-_extends: .github


### PR DESCRIPTION
stale.yml is added so that `stale` probot app can work on this repo. However, this file also gets created whenever someone use `npx create-probot-app`. This PR is to fix this bug by removing the stale.yml file.