### PR TITLE
remove comment for WEBHOOK_PROXY_URL in env sample file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,4 @@ WEBHOOK_SECRET=development
 LOG_LEVEL=debug
 
 # Go to https://smee.io/new set this to the URL that you are redirected to.
-# WEBHOOK_PROXY_URL=
+WEBHOOK_PROXY_URL=


### PR DESCRIPTION
Not sure if this is really worth a pull request, but here you go.

It took me a bit until I notices that the `WEBHOOK_PROXY_URL` was commented out. I would suggest to leave this out and set the env. variable to an empty string. This has the same effect as this evaluates to `false` at https://github.com/probot/probot/blob/master/lib/index.js#L107.

If on the other hand `WEBHOOK_PROXY_URL` should not be used in production, I would rather create a warning message while checking `process.env.NODE_ENV`.