### PR TITLE
Robot => App

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-module.exports = (robot) => {
+module.exports = app => {
   // Your code here
-  robot.log('Yay, the app was loaded!')
+  app.log('Yay, the app was loaded!')
 
   // For more information on building apps:
   // https://probot.github.io/docs/


### PR DESCRIPTION
Continuing the change in https://github.com/probot/probot/pull/542, this PR updates the template repo used by `create-probot-app` to default to using `app` instead of `robot`.

I also removed the parenthesis because they drove me crazy - if you disagree feel free to let me know or change it back, but I didn't think it was worth its own PR.