### PR TITLE
Remove CI badge from template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # {{ name }}
 
-[![Build Status](https://travis-ci.org/probot/{{ name }}.svg?branch=master)](https://travis-ci.org/probot/{{ name }})
-<!-- Note: Update this badge with whatever CI service you would like; at Probot, we generally default to Travis. -->
-
 > A GitHub App built with [Probot](https://github.com/probot/probot) that {{ description }}
 
 ## Setup


### PR DESCRIPTION
Same reasoning as #65.

It especially applies to this because this template will be invalid if I publish an app to `bkeepers/my-awesome-app` because the template is expecting that I am publishing it to the @probot org.