### PR TITLE
Bump Smee version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "jest": "^22.4.3",
     "nodemon": "^1.17.2",
-    "smee-client": "^1.0.1",
+    "smee-client": "^1.0.2",
     "standard": "^10.0.3"
   },
   "engines": {


### PR DESCRIPTION
Bumps the version of `smee-client` to 1.0.2.

[Check out the release](https://github.com/probot/smee/releases/tag/v1.0.2) if you're curious about what this changes.