### PR TITLE
Probot 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
+/**
+ * This is the entry point for your Probot App.
+ * @param {import('probot').Application} app - Probot's Application class.
+ */
 module.exports = app => {
   // Your code here
   app.log('Yay, the app was loaded!')
+
 
   // For more information on building apps:
   // https://probot.github.io/docs/

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:watch": "jest --watch --notify --notifyMode=change --coverage"
   },
   "dependencies": {
-    "probot": "^6.0.0"
+    "probot": "^7.0.0"
   },
   "devDependencies": {
     "jest": "^22.4.3",


### PR DESCRIPTION
<h3 align="center">⚠️ This PR should be merged <em>after</em> Probot 7 has been published⚠️</h3>

---

This PR updates the template repo to use Probot `^7.0.0` (which technically doesn't exist yet). Only two things change:

* Bump the `package.json` version
* Add some JSDoc comments to make use of the new types

Nod to https://github.com/probot/probot/issues/576