### PR TITLE
Refactor variable name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-module.exports = app => {
+module.exports = robot => {
   // Your code here
-  app.log('Yay, the app was loaded!')
+  robot.log('Yay, the app was loaded!')
 
   // For more information on building apps:
   // https://probot.github.io/docs/


### PR DESCRIPTION
A few reasons to use `robot` instead of `app`:

- All the docs use `robot`
- The type/class of the variable is `Robot`
- `app` is used in other examples for a different thing: `const app = robot.route('/my-app');` https://probot.github.io/api/latest/Robot.html