### PR TITLE
Ignores jest coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 *.pem
 .env
 package-lock.json
+coverage


### PR DESCRIPTION
If the `--coverage` flag is used Jest will generate coverage report files in the `coverage` directory, which if not ignored could be tracked by git.

The `--coverage` flag is used in the `test:watch` npm script.