### PR TITLE
Fix lint errors

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,6 @@ const myProbotApp = require('..')
 
 const issuesOpenedPayload = require('./fixtures/issues.opened.json')
 
-
 test('that we can run tests', () => {
   // your real tests go here
   expect(1 + 2 + 3).toBe(6)
@@ -31,7 +30,7 @@ describe('My Probot app', () => {
     // Simulates delivery of an issues.opened webhook
     await app.receive({
       event: 'issues.opened',
-      payload: issuesOpenedPayload,
+      payload: issuesOpenedPayload
     })
 
     // This test passes if the code in your index.js file calls `context.github.issues.createComment`


### PR DESCRIPTION
Fix lint errors introduced in #74 

Just tried out the change from #74 by creating a fresh app using `create-probot-app` and looks like there were 2 lint errors that caused `npm t` to fail! This PR removes the lint errors.

It would probably be a good idea to set up CI on this repo, but not sure about the best way to deal with things like `{{ name }}` in `package.json`