### PR TITLE
Test create-probot-app against this template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ language: node_js
 node_js:
   - "8.3"
 
-matrix:
-  include:
-    - node_js: "10"
-  allow_failures:
-    - node_js: "10"
-
 notifications:
   disabled: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
   disabled: true
 
 install:
-  - npx create-probot-app -n "travis-template-test" -d "A Probot App for building on Travis" -a "Pro Bawt" -e "probot@example.com" -h "https://probot.github.io" -u "probot" -r "template" -b ${TRAVIS_PULL_REQUEST_BRANCH} travis-template-test
+  - npx create-probot-app -n "travis-template-test" -d "A Probot App for building on Travis" -a "Pro Bawt" -e "probot@example.com" -h "https://probot.github.io" -u "probot" -r "template" -b ${TRAVIS_PULL_REQUEST_BRANCH:-TRAVIS_BRANCH} travis-template-test
     
 script:
   - cd travis-template-test && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
   disabled: true
 
 install:
-  - npx create-probot-app -n "travis-template-test" -d "A Probot App for building on Travis" -a "Pro Bawt" -e "probot@example.com" -h "https://probot.github.io" -u "probot" -r "template" travis-template-test
+  - npx create-probot-app -n "travis-template-test" -d "A Probot App for building on Travis" -a "Pro Bawt" -e "probot@example.com" -h "https://probot.github.io" -u "probot" -r "template" -b ${TRAVIS_PULL_REQUEST_BRANCH} travis-template-test
     
 script:
   - cd travis-template-test && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,7 @@ notifications:
   disabled: true
 
 install:
-  - npx create-probot-app \
-    -n travis-template-test \
-    -d "A Probot App for building on Travis" \
-    -a "Pro Bawt" \
-    -e "probot@example.com" \
-    -h "https://probot.github.io" \
-    -u "probot" \
-    -r "template"
+  - npx create-probot-app -n "travis-template-test" -d "A Probot App for building on Travis" -a "Pro Bawt" -e "probot@example.com" -h "https://probot.github.io" -u "probot" -r "template" travis-template-test
     
 script:
   - cd travis-template-test && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,26 @@ sudo: false
 language: node_js
 node_js:
   - "8.3"
+
+matrix:
+  include:
+    - node_js: "10"
+  allow_failures:
+    - node_js: "10"
+
 notifications:
   disabled: true
+
+install:
+  - npx create-probot-app \
+    -n travis-template-test \
+    -d "A Probot App for building on Travis" \
+    -a "Pro Bawt" \
+    -e "probot@example.com" \
+    -h "https://probot.github.io" \
+    -u "probot" \
+    -r "template"
+    
+script:
+  - cd travis-template-test && npm test
+    


### PR DESCRIPTION
As discussed in #75, because of the handlebars template variables we use in `package.json`, the normal `npm test` command doesn't work in Travis. This PR will update the `.travis.yml` file to run `create-probot-app` in Travis, then run the tests in the cloned template. We'll need to ensure Travis scaffolds the repo from the right branch, so I'm thinking in addition to this we add a command-line flag to `create-probot-app` that allows you to specify a branch of the template repo(which is an option available in [`scaffold`](https://github.com/boneskull/egad#basic-usage)). We would then pass the `${TRAVIS_PULL_REQUEST_BRANCH}` environment variable to this script.

The goal is to ensure any changes to this template can successfully scaffold an app with all the available options and run a clean `npm test`.