### PR TITLE
Jest security error

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
       "jest"
     ]
   },
+  "jest": {
+    "testEnvironment": "node"
+  },
   "nodemonConfig": {
     "exec": "npm start",
     "watch": [".env", "."]


### PR DESCRIPTION
The out-of-the-box test is failing with the following:

```
 ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)
``` 

Adding a Jest specific config in `package.json` does the trick. 