### PR TITLE
Propery `event` is deprecated, use `name`

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,7 +29,7 @@ describe('My Probot app', () => {
   test('creates a comment when an issue is opened', async () => {
     // Simulates delivery of an issues.opened webhook
     await app.receive({
-      event: 'issues.opened',
+      name: 'issues.opened',
       payload: issuesOpenedPayload
     })
 


### PR DESCRIPTION
Getting an error when running the out-of-the-box test:

```
Error: Propery `event` is deprecated, use `name`
        at Application.<anonymous> (/Users/helaili/workspace/my-first-app/node_modules/probot/lib/application.js:94:34)
        at step (/Users/helaili/workspace/my-first-app/node_modules/probot/lib/application.js:40:23)
        at Object.next (/Users/helaili/workspace/my-first-app/node_modules/probot/lib/application.js:21:53)
        at /Users/helaili/workspace/my-first-app/node_modules/probot/lib/application.js:15:71
        at new Promise (<anonymous>)
        at Object.<anonymous>.__awaiter (/Users/helaili/workspace/my-first-app/node_modules/probot/lib/application.js:11:12)
        at Application.Object.<anonymous>.Application.receive (/Users/helaili/workspace/my-first-app/node_modules/probot/lib/application.js:90:16)
        at Object.test (/Users/helaili/workspace/my-first-app/test/index.test.js:30:15)
        at Object.asyncFn (/Users/helaili/workspace/my-first-app/node_modules/jest-jasmine2/build/jasmine_async.js:82:37)
        at resolve (/Users/helaili/workspace/my-first-app/node_modules/jest-jasmine2/build/queue_runner.js:52:12)
        at new Promise (<anonymous>)
        at mapper (/Users/helaili/workspace/my-first-app/node_modules/jest-jasmine2/build/queue_runner.js:39:19)
        at promise.then (/Users/helaili/workspace/my-first-app/node_modules/jest-jasmine2/build/queue_runner.js:73:82)
        at <anonymous>
        at process._tickCallback (internal/process/next_tick.js:188:7)
``` 