### PR TITLE
Link to website instead of GitHub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # {{ name }}
 
-> A GitHub App built with [Probot](https://github.com/probot/probot) that {{ description }}
+> A GitHub App built with [Probot](https://probot.github.io) that {{ description }}
 
 ## Setup
 


### PR DESCRIPTION
> A GitHub App built with [Probot](https://probot.github.io) that…

This PR updates ☝️ to link to the [website](https://probot.github.io) instead of the [repo](https://github.com/probot/probot). Since users that may click that link likely haven't heard of Probot before, I think the website is a more helpful introduction than the repository.