### PR TITLE
escape all template variables

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at {{{ email }}}. All
+reported by contacting the project team at {{ email }}. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) {{{ year }}}, {{{ author }}}
+Copyright (c) {{ year }}, {{ author }}
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ For more, check out the [Contributing Guide](CONTRIBUTING.md).
 
 ## License
 
-[ISC](LICENSE) © {{{ year }}} {{{ author }}}
+[ISC](LICENSE) © {{ year }} {{ author }}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "{{ name }}",
   "version": "1.0.0",
-  "description": "{{{ description }}}",
-  "author": "{{{ author }}}",
+  "description": "{{ description }}",
+  "author": "{{ author }}",
   "license": "ISC",
   "repository": "https://github.com/{{ owner }}/{{ repo }}.git",
   "homepage": "https://github.com/{{ owner }}/{{ repo }}",


### PR DESCRIPTION
## What
Escape all handlebars template variables

## Why
Currently `description` is causing issues when it contains double quotes as they break the package.json file by making the resulting JSON file invalid. As discussed in https://github.com/probot/probot/issues/727 we can escape _all_ variables and if something was encoded improperly it's up to the end user to fix the template issues. While it's a minor inconvenience, this guarantees that the `create-probot-app` template _always_ works at the cost of potentially HTML escaping something we didn't want to.

cc: @hiimbex 

-----
[View rendered CODE_OF_CONDUCT.md](https://github.com/dmlittle/template/blob/master/CODE_OF_CONDUCT.md)
[View rendered README.md](https://github.com/dmlittle/template/blob/master/README.md)